### PR TITLE
Widen peer range

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-version-checker": "^5.1.2"
   },
   "peerDependencies": {
-    "ember-source": "^3.25.0 || ^4.0.0"
+    "ember-source": "^3.25.0 || >=4.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",


### PR DESCRIPTION
Folks should not be using this polyfill after v4.5, but addons may include it to support a wide range of consumers.

The polyfill no-op's after v4.5